### PR TITLE
chatterino homies custom per user badges support

### DIFF
--- a/app/src/lib/badgeParser.ts
+++ b/app/src/lib/badgeParser.ts
@@ -127,18 +127,18 @@ export function parseBadges(
     }
 
     const foundCustomHomiesBadges = (
-        Array.isArray(badges_data?.OTHER?.CustomHomies)
-            ? badges_data.OTHER.CustomHomies
-            : []
-    ).filter((badge: any) => badge?.owners?.includes(userstate["user-id-raw"]));
+        badges_data?.OTHER?.CustomHomies ?? []
+    ).filter((badge: { owners?: string[]; url?: string; title?: string }) =>
+        badge?.owners?.includes(userstate["user-id-raw"]),
+    );
 
-    foundCustomHomiesBadges.forEach((badge: any) => {
+    for (const badge of foundCustomHomiesBadges) {
         user_badges.push({
             badge_url: badge.url,
             alt: badge.title,
             background_color: undefined,
         });
-    });
+    }
 
     // FFZ
     const foundFFZBadges = badges_data["FFZ"]["global"].filter(

--- a/app/src/lib/badgeParser.ts
+++ b/app/src/lib/badgeParser.ts
@@ -113,7 +113,8 @@ export function parseBadges(
     // CHATTERINO & CHATTERINO HOMIES
     const foundChatterinoBadges = [
         ...badges_data["OTHER"]["Chatterino"],
-        ...badges_data["OTHER"]["ChatterinoHomies"],
+        ...badges_data["OTHER"]["CustomHomies"],
+	...badges_data["OTHER"]["ChatterinoHomies"],
     ].filter((badge) => badge.owners.includes(userstate["user-id-raw"]));
 
     if (foundChatterinoBadges) {

--- a/app/src/lib/badgeParser.ts
+++ b/app/src/lib/badgeParser.ts
@@ -114,7 +114,7 @@ export function parseBadges(
     const foundChatterinoBadges = [
         ...badges_data["OTHER"]["Chatterino"],
         ...badges_data["OTHER"]["CustomHomies"],
-	...badges_data["OTHER"]["ChatterinoHomies"],
+        ...badges_data["OTHER"]["ChatterinoHomies"],
     ].filter((badge) => badge.owners.includes(userstate["user-id-raw"]));
 
     if (foundChatterinoBadges) {

--- a/app/src/lib/badgeParser.ts
+++ b/app/src/lib/badgeParser.ts
@@ -113,7 +113,6 @@ export function parseBadges(
     // CHATTERINO & CHATTERINO HOMIES
     const foundChatterinoBadges = [
         ...badges_data["OTHER"]["Chatterino"],
-        ...badges_data["OTHER"]["CustomHomies"],
         ...badges_data["OTHER"]["ChatterinoHomies"],
     ].filter((badge) => badge.owners.includes(userstate["user-id-raw"]));
 
@@ -126,6 +125,20 @@ export function parseBadges(
             });
         });
     }
+
+    const foundCustomHomiesBadges = (
+        Array.isArray(badges_data?.OTHER?.CustomHomies)
+            ? badges_data.OTHER.CustomHomies
+            : []
+    ).filter((badge: any) => badge?.owners?.includes(userstate["user-id-raw"]));
+
+    foundCustomHomiesBadges.forEach((badge: any) => {
+        user_badges.push({
+            badge_url: badge.url,
+            alt: badge.title,
+            background_color: undefined,
+        });
+    });
 
     // FFZ
     const foundFFZBadges = badges_data["FFZ"]["global"].filter(

--- a/app/src/lib/badges.ts
+++ b/app/src/lib/badges.ts
@@ -107,6 +107,30 @@ export async function getChatterinoHomiesBadges() {
     });
 }
 
+export async function getCustomHomiesBadges() {
+    const response = await fetch(
+        "https://chatterinohomies.com/api/badges/list",
+    );
+    const data = await response.json();
+
+    const badgesRaw = Array.isArray(data?.badges) ? data.badges : [];
+
+    const map = badgesRaw.map((badge: any, index: number) => ({
+        id: badge.badgeId || `customhomies_${index}`,
+        url: badge.image3 || badge.image2 || badge.image1 || undefined,
+        title: badge.tooltip || "CustomHomies Badge",
+        owners: badge.userId ? [badge.userId] : [],
+        username: badge.username,
+        urls: { 1: badge.image1, 2: badge.image2, 4: badge.image3 },
+    }));
+
+    badges.update((e) => {
+        e["OTHER"]["CustomHomies"] = map;
+
+        return e;
+    });
+}
+
 export async function getPolandBOTBadges() {
     const response = await fetch("https://devpoland.xyz/api/roles");
     const data = await response.json();

--- a/app/src/lib/loadChat.ts
+++ b/app/src/lib/loadChat.ts
@@ -1,6 +1,7 @@
 import {
     getBTTVBadges,
     getChatterinoBadges,
+    getCustomHomiesBadges,
     getChatterinoHomiesBadges,
     getFFZBadges,
     getMainBadges,
@@ -21,6 +22,7 @@ export async function initChat() {
         getBTTVBadges(),
         getFFZBadges(),
         getChatterinoBadges(),
+        getCustomHomiesBadges(),
         getChatterinoHomiesBadges(),
         getPolandBOTBadges(),
         getTurtegBotBadges(),

--- a/app/src/stores/global.ts
+++ b/app/src/stores/global.ts
@@ -48,6 +48,7 @@ interface Badges {
     };
     OTHER: {
         Chatterino: any[];
+        CustomHomies: Record<string, string[]>;
         ChatterinoHomies: any[];
         PolandBOT: Record<string, string[]>;
         TurtegBot: any[];
@@ -69,6 +70,7 @@ export const badges = writable<Badges>({
     FFZ: { global: [], user: { vip: "", mod: "", user: {} } },
     OTHER: {
         Chatterino: [],
+        CustomHomies: {},
         ChatterinoHomies: [],
         PolandBOT: {},
         TurtegBot: [],


### PR DESCRIPTION
## Proposed changes

In this PR, I added support for Chatterino Homies custom per user badges.

## Link to the API Pull request (if API change required):

...

## Notes

If this PR depends on the API, make sure to test it against a local build using [this repo](https://github.com/Fiszh/uniiDev) before merging.

## Checklist

Put an `x` in the boxes that apply. You can also fill them out later after creating the PR.
</br>Do not remove any of the checkboxes.

- [x] I agree to the guidelines outlined in [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] The code is readable and follows the existing style.
- [x] Any new non-first-party API endpoints do not send user data (telemetry, analytics, etc.).
- [ ] This change could be breaking.
- [ ] This PR depends on an API or backend change.
    - [ ] I have tested it against a local build using [this repo](https://github.com/Fiszh/uniiDev) and opened a corresponding PR there.
- [ ] This PR adds my bot to the custom bot list.
    - [ ] My bot is not recognized as a bot by [Twitch](https://help.twitch.tv/s/article/chat-bot-badge-about) or [FFZ](https://api.frankerfacez.com/v1/badges).
    - [ ] The bot is publicly accessible (not private or test-only).
- [ ] This PR adds a new setting.
- [ ] This PR adds or changes CSS.
    - [ ] Mobile only.
    - [ ] PC only.
    - [ ] Both.
